### PR TITLE
Build outside the docker

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,11 +4,9 @@ name: deploy
   push:
     branches:
       - master
+      - trying
       - fixup-deploy
 env:
-  CI: 1
-  RUST_BACKTRACE: full
-  RUSTC_BOOTSTRAP: 1
   DOCKER_BUILDKIT: 1
 jobs:
   docker:
@@ -17,6 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build invoker
-        run: "docker build -t ghcr.io/jjs-dev/jjs-invoker:latest .\n"
+        run: "bash build.sh --release\n"
       - name: Upload images
-        run: "echo ${{ secrets.GHCR_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin\ndocker push ghcr.io/jjs-dev/jjs-invoker:latest\n"
+        run: "if [ \"$GITHUB_REF\" = \"refs/heads/master\" ] || [ \"$GITHUB_REF\" = \"refs/heads/fixup-deploy\" ]\nthen\n  TAG=\"latest\"\nelif [ \"$GITHUB_REF\" = \"refs/heads/trying\" ]\nthen\n  TAG=\"trying\"\nelse\n  echo \"unknown GITHUB_REF: $GITHUB_REF\"\n  exit 1\nfi\n\ndocker tag jjs-invoker ghcr.io/jjs-dev/jjs-invoker:$TAG\necho ${{ secrets.GHCR_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin\ndocker push ghcr.io/jjs-dev/jjs-invoker:$TAG\n"

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -137,7 +137,7 @@ jobs:
           path: target
           key: "${{ runner.os }}-e2e-${{ steps.rustc_version.outputs.version }}-${{ hashFiles('Cargo.lock') }}"
       - name: Build invoker
-        run: docker build -f Dockerfile -t jjs-invoker .
+        run: bash build.sh
       - name: Run tests
         run: "mkdir /tmp/logs\ncargo run -p test-runner -- --image=jjs-invoker --logs=/tmp/logs\n"
       - name: Upload logs

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,6 @@
-FROM rust:1.49 AS builder
-WORKDIR /app
-COPY ./src/invoker/Cargo.toml ./
-# This way dependencies will be cached separately from invoker source,
-# so code changes will not invalidate the whole build.
-RUN mkdir ./src && \
-    echo 'fn main(){}' > ./src/main.rs && \
-    cargo build --release && \
-    rm -r ./src/
-COPY ./src/invoker ./
-RUN touch src/main.rs && \
-    cargo build --release
-
 FROM debian:stable-slim
 RUN apt-get update && apt-get install -y curl
-COPY --from=builder /app/target/release/invoker /bin/invoker
+COPY out/invoker /bin/invoker
 COPY /scripts/docker-entrypoint.sh /entry.sh
 ENTRYPOINT [ "/bin/bash", "/entry.sh" ]
 VOLUME ["/var/judges"]

--- a/Readme.md
+++ b/Readme.md
@@ -3,6 +3,11 @@
 # JJS Invoker
 This is component of [JJS Judging system](https://github.com/jjs-dev/jjs)
 
+## Building
+```bash
+bash build.sh
+```
+
 ## License
 Licensed under either of
 - [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/actions/deploy.yaml
+++ b/actions/deploy.yaml
@@ -3,11 +3,9 @@ on:
   push:
     branches:
       - master
+      - trying
       - fixup-deploy
 env:
-  CI: 1
-  RUST_BACKTRACE: full
-  RUSTC_BOOTSTRAP: 1
   DOCKER_BUILDKIT: 1
 jobs:
   docker:
@@ -17,8 +15,20 @@ jobs:
       - uses: actions/checkout@v2
       - name: Build invoker
         run: |
-          docker build -t ghcr.io/jjs-dev/jjs-invoker:latest .
+          bash build.sh --release
       - name: Upload images
         run: |
+          if [ "$GITHUB_REF" = "refs/heads/master" ] || [ "$GITHUB_REF" = "refs/heads/fixup-deploy" ]
+          then
+            TAG="latest"
+          elif [ "$GITHUB_REF" = "refs/heads/trying" ]
+          then
+            TAG="trying"
+          else
+            echo "unknown GITHUB_REF: $GITHUB_REF"
+            exit 1
+          fi
+          
+          docker tag jjs-invoker ghcr.io/jjs-dev/jjs-invoker:$TAG
           echo ${{ secrets.GHCR_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
-          docker push ghcr.io/jjs-dev/jjs-invoker:latest
+          docker push ghcr.io/jjs-dev/jjs-invoker:$TAG

--- a/actions/pr.yaml
+++ b/actions/pr.yaml
@@ -124,7 +124,7 @@ jobs:
           path: target
           key: ${{ runner.os }}-e2e-${{ steps.rustc_version.outputs.version }}-${{ hashFiles('Cargo.lock') }}
       - name: Build invoker
-        run: docker build -f Dockerfile -t jjs-invoker .
+        run: bash build.sh
       - name: Run tests
         run: |
           mkdir /tmp/logs

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env
+set -euxo pipefail
+# Builds invoker docker image
+# All arguments are passed to cargo
+
+RUSTC_BOOTSTRAP=1 cargo build -p invoker "$@" -Zunstable-options --out-dir ./out
+
+docker build -t jjs-invoker .

--- a/out/.gitignore
+++ b/out/.gitignore
@@ -1,0 +1,1 @@
+invoker


### PR DESCRIPTION
Since cargo itself is pure and idempotent, there is no benefits
in running it inside docker. On the other hand caching is easier
to achieve now.